### PR TITLE
Update builder.json: small schema fixes

### DIFF
--- a/internal/fs/schemas/builder.json
+++ b/internal/fs/schemas/builder.json
@@ -69,10 +69,7 @@
         },
         "compound": {
           "type": "string",
-          "description": "Compound filter to use, as typed in -S filters on the CLI",
-          "items": {
-            "type": "string"
-          }
+          "description": "Compound filter to use, as typed in -S filters on the CLI"
         },
         "discovery_method": {
           "type": "string",
@@ -236,8 +233,7 @@
             },
             "commands": {
               "description": "Additional CLI commands to add",
-              "$ref": "#/definitions/commands",
-              "minLength": 1
+              "$ref": "#/definitions/commands"
             }
           }
         }
@@ -245,7 +241,7 @@
     },
     "discover_command": {
       "type": "object",
-      "default": "A command that does Choria based node discovery",
+      "description": "A command that does Choria based node discovery",
       "additionalItems": false,
       "allOf": [
         {


### PR DESCRIPTION
Some minor, syntactically (and hopefully semantically!) correct fixes that emerged as I played around with manually importing this schema into CUE and validated a demo CLI .yaml against it.

1. objects can't both be a string, and /contain/ items that are strings
1. `minLength` only applies to strings, not arrays
1. using `default`, while valid from a JSONSchema perspective (~"default is an advisory label"), confuses CUE, as CUE tries to use it as a concrete default value (which isn't a valid type conversion for the object it's defined against). It's also inconsistent with the rest of the schema - I /think/ `description` is what was intended.
